### PR TITLE
Fix info level

### DIFF
--- a/pylint_actions/__init__.py
+++ b/pylint_actions/__init__.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
     from pylint.lint.pylinter import PyLinter
 
 levels = {
-    "I": "info",
-    "C": "info",
-    "R": "info",
+    "I": "notice",
+    "C": "notice",
+    "R": "notice",
     "W": "warning",
     "E": "error",
     "F": "error",


### PR DESCRIPTION
Thank you for creating this GitHub action!

I found a little bug: The info level ist not working.

`info` is not a valid command, `notice` seem to be a got replacement.

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message

The example run should now also annotate info level messages.

Thank you again.